### PR TITLE
Removed unnecessary .smx output to the log

### DIFF
--- a/addons/sourcemod/scripting/gamevoting/detect.sp
+++ b/addons/sourcemod/scripting/gamevoting/detect.sp
@@ -18,7 +18,7 @@ public bool detect_ban_system(int type) {
 	BuildPath(Path_SM, file_path, sizeof(file_path), "plugins/%s.smx", filename);
 	LogMessage("[GameVoting] Checking ban system: %s", file_path);
 	if(FileExists(file_path)) {
-		LogToFile(LogFilePath, "[GameVoting] Founded ban system: %s.smx", file_path);
+		LogToFile(LogFilePath, "[GameVoting] Founded ban system: %s", file_path);
 		is_bansys[type] = true;
 		return true;
 	}


### PR DESCRIPTION
Before:
L 07/09/2022 - 22:11:21: [gamevoting.smx] [GameVoting] Founded ban system: addons/sourcemod/plugins/materialadmin.smx.smx
L 07/09/2022 - 22:11:21: [gamevoting.smx] [GameVoting] Founded ban system: addons/sourcemod/plugins/ma_basecomm.smx.smx
After:
L 07/09/2022 - 22:16:52: [gamevoting.smx] [GameVoting] Founded ban system: addons/sourcemod/plugins/materialadmin.smx
L 07/09/2022 - 22:16:52: [gamevoting.smx] [GameVoting] Founded ban system: addons/sourcemod/plugins/ma_basecomm.smx